### PR TITLE
Quanstamp initial report

### DIFF
--- a/contracts/InverseApi3ReaderProxyV1.sol
+++ b/contracts/InverseApi3ReaderProxyV1.sol
@@ -24,10 +24,7 @@ contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
     }
 
     /// @notice Returns the inverted value of the underlying IApi3ReaderProxy
-    /// @dev This inverts the 18-decimal fixed-point value using 1e36 / value.
-    /// The operation will revert if `baseValue` is zero (division by zero) or if
-    /// `baseValue` is so small (yet non-zero) that the resulting inverted value
-    /// would overflow the `int224` type.
+    /// @dev The operation will revert if `baseValue` is zero (division by zero).
     /// @return value Inverted value of the underlying proxy
     /// @return timestamp Timestamp of the underlying proxy
     function read()
@@ -39,7 +36,7 @@ contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
         (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxy(proxy)
             .read();
 
-        value = int224((1e36) / int256(baseValue));
+        value = int224(1e36) / baseValue;
         timestamp = baseTimestamp;
     }
 

--- a/contracts/InverseApi3ReaderProxyV1.sol
+++ b/contracts/InverseApi3ReaderProxyV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "./interfaces/IInverseApi3ReaderProxyV1.sol";

--- a/contracts/InverseApi3ReaderProxyV1.sol
+++ b/contracts/InverseApi3ReaderProxyV1.sol
@@ -24,7 +24,9 @@ contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
     }
 
     /// @notice Returns the inverted value of the underlying IApi3ReaderProxy
-    /// @dev The operation will revert if `baseValue` is zero (division by zero).
+    /// @dev Calculates `int224(1e36) / baseValue`. The operation will revert if
+    /// `baseValue` is zero. If `baseValue` is non-zero but its absolute value is
+    /// greater than `1e36`, the result of the integer division will be `0`.
     /// @return value Inverted value of the underlying proxy
     /// @return timestamp Timestamp of the underlying proxy
     function read()

--- a/contracts/InverseApi3ReaderProxyV1.sol
+++ b/contracts/InverseApi3ReaderProxyV1.sol
@@ -38,6 +38,10 @@ contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
         (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxy(proxy)
             .read();
 
+        if (baseValue == 0) {
+            revert DivisionByZero();
+        }
+
         value = int224(1e36) / baseValue;
         timestamp = baseTimestamp;
     }

--- a/contracts/NormalizedApi3ReaderProxyV1.sol
+++ b/contracts/NormalizedApi3ReaderProxyV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import "./interfaces/INormalizedApi3ReaderProxyV1.sol";
 

--- a/contracts/NormalizedApi3ReaderProxyV1.sol
+++ b/contracts/NormalizedApi3ReaderProxyV1.sol
@@ -45,15 +45,9 @@ contract NormalizedApi3ReaderProxyV1 is INormalizedApi3ReaderProxyV1 {
 
     /// @notice Returns the price of the underlying Chainlink feed normalized to
     /// 18 decimals.
-    /// @dev Fetches an `int256` answer from the Chainlink feed and scales it
-    /// to 18 decimals using pre-calculated factors. The result is cast to
-    /// `int224` to conform to the `IApi3ReaderProxy` interface.
-    /// IMPORTANT: If the normalized `int256` value is outside the `int224`
-    /// range, this cast causes silent truncation and data loss. Deployers
-    /// must verify that the source feed's characteristics (value magnitude
-    /// and original decimals) ensure the 18-decimal normalized value fits
-    /// `int224`. Scaling arithmetic (prior to cast) reverts on `int256`
-    /// overflow.
+    /// @dev Fetches and scales the Chainlink feed's `int256` answer.
+    /// The scaled `int256` result is then cast to `int224`. This cast is
+    /// unchecked for gas optimization and may silently truncate.
     /// @return value The normalized signed fixed-point value with 18 decimals
     /// @return timestamp The updatedAt timestamp of the feed
     function read()

--- a/contracts/PriceCappedApi3ReaderProxyV1.sol
+++ b/contracts/PriceCappedApi3ReaderProxyV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "./interfaces/IPriceCappedApi3ReaderProxyV1.sol";

--- a/contracts/ProductApi3ReaderProxyV1.sol
+++ b/contracts/ProductApi3ReaderProxyV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "./interfaces/IProductApi3ReaderProxyV1.sol";

--- a/contracts/ProductApi3ReaderProxyV1.sol
+++ b/contracts/ProductApi3ReaderProxyV1.sol
@@ -33,9 +33,13 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
 
     /// @notice Returns the current value and timestamp of the rate composition
     /// between two IApi3ReaderProxy proxies by multiplying their values
-    /// @dev There is a risk of multiplication overflowing if the result exceeds
-    /// `int256` bounds. The returned timestamp is `block.timestamp`, marking
-    /// when this newly derived product value was computed on-chain.
+    /// @dev Calculates product as `(int256(value1) * int256(value2)) / 1e18`.
+    /// The initial multiplication `int256(value1) * int256(value2)` will revert
+    /// on `int256` overflow. The final `int256` result of the full expression
+    /// is then cast to `int224`. This cast is unchecked for gas optimization
+    /// and may silently truncate if the result exceeds `int224` limits.
+    /// The returned timestamp is `block.timestamp`, marking when this newly
+    /// derived product value was computed on-chain.
     /// Timestamps from underlying `IApi3ReaderProxy` feeds are not aggregated.
     /// Their diverse nature (see `IApi3ReaderProxy` interface for details like
     /// off-chain origins or varying update cadences) makes aggregation complex

--- a/contracts/ProductApi3ReaderProxyV1.sol
+++ b/contracts/ProductApi3ReaderProxyV1.sol
@@ -38,12 +38,9 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
     /// on `int256` overflow. The final `int256` result of the full expression
     /// is then cast to `int224`. This cast is unchecked for gas optimization
     /// and may silently truncate if the result exceeds `int224` limits.
-    /// The returned timestamp is `block.timestamp`, marking when this newly
-    /// derived product value was computed on-chain.
-    /// Timestamps from underlying `IApi3ReaderProxy` feeds are not aggregated.
-    /// Their diverse nature (see `IApi3ReaderProxy` interface for details like
-    /// off-chain origins or varying update cadences) makes aggregation complex
-    /// and potentially misleading for this product's timestamp.
+    /// The returned timestamp is `block.timestamp`, reflecting the on-chain
+    /// computation time of the product. Underlying feed timestamps are not
+    /// aggregated due to complexity and potential for misinterpretation.
     /// @return value Value of the product of the two proxies
     /// @return timestamp Timestamp of the current block
     function read()

--- a/contracts/ProductApi3ReaderProxyV1.sol
+++ b/contracts/ProductApi3ReaderProxyV1.sol
@@ -34,7 +34,7 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
     /// @notice Returns the current value and timestamp of the rate composition
     /// between two IApi3ReaderProxy proxies by multiplying their values
     /// @dev Calculates product as `(int256(value1) * int256(value2)) / 1e18`.
-    /// The initial multiplication `int256(value1) * int256(value2)` will revert
+    /// The initial multiplication `int256(value1) * int256(value2)` may revert
     /// on `int256` overflow. The final `int256` result of the full expression
     /// is then cast to `int224`. This cast is unchecked for gas optimization
     /// and may silently truncate if the result exceeds `int224` limits.

--- a/contracts/adapters/ScaledApi3FeedProxyV1.sol
+++ b/contracts/adapters/ScaledApi3FeedProxyV1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "./interfaces/IScaledApi3FeedProxyV1.sol";

--- a/contracts/adapters/ScaledApi3FeedProxyV1.sol
+++ b/contracts/adapters/ScaledApi3FeedProxyV1.sol
@@ -7,8 +7,14 @@ import "./interfaces/IScaledApi3FeedProxyV1.sol";
 /// @title An immutable Chainlink AggregatorV2V3Interface feed contract that
 /// scales the value of an IApi3ReaderProxy data feed to a target number of
 /// decimals
-/// @dev This contract assumes the source proxy always returns values with
-/// 18 decimals (as all IApi3ReaderProxy-compatible proxies do)
+/// @dev This contract reads an `int224` value (assumed to be 18 decimals)
+/// from the underlying `IApi3ReaderProxy` and scales it to `targetDecimals`.
+/// The scaling arithmetic uses `int256` for intermediate results, allowing the
+/// scaled value to exceed `int224` limits if upscaling significantly; it will
+/// revert on `int256` overflow.
+/// When downscaling, integer division (`proxyValue / scalingFactor`) is used,
+/// which truncates and may lead to precision loss. Integrators must carefully
+/// consider this potential precision loss for their specific use case.
 contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
     /// @notice IApi3ReaderProxy contract address
     address public immutable override proxy;
@@ -133,15 +139,10 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
 
     /// @notice Reads a value from the underlying `IApi3ReaderProxy` and
     /// scales it to `targetDecimals`.
-    /// @dev Reads an `int224` value (assumed to be 18 decimals) from the
-    /// underlying `IApi3ReaderProxy`. This value is then scaled to
-    /// `targetDecimals` using pre-calculated factors. The scaling arithmetic
-    /// (e.g., `proxyValue * scalingFactor`) involves an `int224` (`proxyValue`)
-    /// and an `int256` (`scalingFactor`). `proxyValue` is implicitly promoted
-    /// to `int256` for this operation, resulting in an `int256` value.
-    /// This allows the scaled result to exceed the `int224` range, provided
-    /// it fits within `int256`. Arithmetic operations will revert on `int256`
-    /// overflow. The function returns the scaled value as an `int256`.
+    /// @dev Reads from the underlying proxy and applies scaling to
+    /// `targetDecimals`. Upscaling uses multiplication; downscaling uses integer
+    /// division (which truncates). All scaling arithmetic is performed using
+    /// `int256`.
     /// @return value The scaled signed fixed-point value with `targetDecimals`.
     /// @return timestamp The timestamp from the underlying proxy.
     function _read() internal view returns (int256 value, uint32 timestamp) {

--- a/contracts/test/MockAggregatorV2V3.sol
+++ b/contracts/test/MockAggregatorV2V3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.27;
+pragma solidity 0.8.27;
 
 import "../vendor/@chainlink/contracts@1.2.0/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol";
 


### PR DESCRIPTION
DFP-1
  * Acknowledge
  * Commit: 4ad5de1
  * Response: The absence of explicit bounds checks for the int256 to int224 cast in ProductApi3ReaderProxyV1.sol and NormalizedApi3ReaderProxyV1.sol is a deliberate trade-off for gas optimization in the read() functions. This design choice means that silent truncation may occur if the intermediate int256 result exceeds int224 limits, a behavior now clearly documented in their respective NatSpec comments.

For InverseApi3ReaderProxyV1.sol, the read() function's formula was updated to value = int224(1e36) / baseValue;. With this change, the division occurs directly between int224 types, and thus the specific concern regarding silent truncation from an intermediate int256 cast is not directly applicable to this revised calculation. Its NatSpec comment has been updated to accurately reflect the current operation.

DFP-2
  * Acknowledge
  * Commit: f94bac9q
  * Response:  The ProductApi3ReaderProxyV1.read() function intentionally returns block.timestamp. This design choice by Api3 reflects that the timestamp accurately marks the on-chain computation time of the derived product value. Aggregating timestamps from underlying feeds is avoided due to complexity and the potential for misinterpretation. Integrators are responsible for checking the staleness of individual underlying feeds directly if required, as per Api3's integration guidelines (https://docs.api3.org/dapps/integration/contract-integration.html#using-timestamp). The contract's NatSpec documents this behavior.

DFP-3
  * Acknowledge
  * Commit: 2ff87d9
  * Response: The potential for the read() function in InverseApi3ReaderProxyV1.sol to return 0 due to integer division underflow is an intentional design choice. This prioritizes maximum gas efficiency for this "highly unlikely" scenario, rather than adding an explicit check to revert. This behavior is now documented in the contract's NatSpec comment for the read() function.

DFP-4
  * Acknowledge
  * Commit: e70c71f
  * Response: The potential for precision loss when downscaling values in ScaledApi3FeedProxyV1.sol is an intentional design choice. This approach prioritizes flexibility for integrators who may require feeds with fewer decimals, rather than restricting the contract's scaling capabilities. The responsibility for assessing and managing the impact of any such precision loss rests with the integrating protocol. This behavior, including the use of integer division which truncates during downscaling, is now clearly documented in the contract's main NatSpec.

S1
  * Fixed
  * Commit: ecfd948
  * Response: 

S2
  * Fixed
  * Commit: 16751b3
  * Response: Reverting with the custom DivisionByZero() error is more gas-efficient and provides clearer error semantics than Solidity's default panic, with minimal gas impact on successful reads.

S3
  * Unresolved
  * Commit: 
  * Response: The current latestRoundData implementation uses named return variables for explicitness and consistency with Api3ReaderProxyV1.sol from the @api3/contracts repository. The potential gas savings from switching to a direct tuple return are considered negligible and do not outweigh the benefits of the current approach in terms of code legibility and established patterns.