### PR TITLE
Adds `dappId` to combinator contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,10 @@ The `NETWORK` variable should be set to a chain name as defined by `@api3/contra
 - **`NormalizedApi3ReaderProxyV1`**:
   - `NETWORK`: Target network name.
   - `FEED`: Address of the external data feed (e.g., a Chainlink `AggregatorV2V3Interface` compatible feed).
+  - `DAPP_ID`: The dApp ID to associate with this proxy.
   - Example:
     ```bash
-    NETWORK=polygon FEED=0xExternalFeedAddress pnpm deploy:NormalizedApi3ReaderProxyV1
+    NETWORK=polygon FEED=0xExternalFeedAddress DAPP_ID=YourDappId pnpm deploy:NormalizedApi3ReaderProxyV1
     ```
 
 - **`ProductApi3ReaderProxyV1`**:
@@ -183,13 +184,13 @@ Imagine your dApp requires a USD/ETH price feed with 8 decimal places, but the a
 1.  **Deploy `InverseApi3ReaderProxyV1`**:
     - Input `PROXY`: Address of the ETH/USD `IApi3ReaderProxy` dAPI.
     - Output: An `IApi3ReaderProxy` contract. This deployed instance of `InverseApi3ReaderProxyV1` reads USD/ETH.
-    - Example command: `NETWORK=your_network PROXY=0xAddressOfEthUsdDapi pnpm deploy:InverseApi3ReaderProxyV1`
+    - Example command: `NETWORK=base PROXY=0xAddressOfEthUsdDapi pnpm deploy:InverseApi3ReaderProxyV1`
 
 2.  **Deploy `ScaledApi3FeedProxyV1`**:
     - Input `PROXY`: Address of the `InverseApi3ReaderProxyV1` instance deployed in step 1.
     - Input `DECIMALS`: `8`.
     - Output: An `AggregatorV2V3Interface` contract. This deployed instance of `ScaledApi3FeedProxyV1` reads USD/ETH scaled to 8 decimals.
-    - Example command: `NETWORK=your_network PROXY=0xAddressOfDeployedInverseApi3ReaderProxyV1FromStep1 DECIMALS=8 pnpm deploy:ScaledApi3FeedProxyV1`
+    - Example command: `NETWORK=base PROXY=0xAddressOfDeployedInverseApi3ReaderProxyV1FromStep1 DECIMALS=8 pnpm deploy:ScaledApi3FeedProxyV1`
       _Note: Replace `0xAddressOfDeployedInverseApi3ReaderProxyV1FromStep1` with the actual address obtained from the deployment artifact of step 1._
 
 This pipeline successfully provides the dApp with the required USD/ETH feed at the desired precision and interface.
@@ -229,8 +230,9 @@ To derive the desired uStETH/USD feed and make it compatible with the Api3 ecosy
 1.  **Deploy `NormalizedApi3ReaderProxyV1`**:
     - This step adapts the external uStETH/ETH feed, which implements the `AggregatorV2V3Interface`, to the `IApi3ReaderProxy` interface. A key function of `NormalizedApi3ReaderProxyV1` is to read the `decimals()` from the external feed and automatically scale its value to the 18 decimal places expected by the `IApi3ReaderProxy` interface. For instance, if the uStETH/ETH feed returns its value with a different precision (e.g., 8 or 36 decimals), this proxy will normalize it.
     - Input `FEED`: Address of the external uStETH/ETH `AggregatorV2V3Interface` feed.
+    - Input `DAPP_ID`: The dApp ID to associate with this proxy.
     - Output: An `IApi3ReaderProxy` contract. This deployed instance of `NormalizedApi3ReaderProxyV1` reads uStETH/ETH, with its value normalized to 18 decimals.
-    - Example command: `NETWORK=your_network FEED=0xAddressOfExternal_uStETH_ETH_Feed pnpm deploy:NormalizedApi3ReaderProxyV1`
+    - Example command: `NETWORK=base FEED=0xAddressOfExternal_uStETH_ETH_Feed DAPP_ID=YourDappId pnpm deploy:NormalizedApi3ReaderProxyV1`
 
 2.  **Deploy `ProductApi3ReaderProxyV1` to calculate uStETH/USD**:
     - This step multiplies the normalized uStETH/ETH rate by the ETH/USD rate from the Api3 dAPI.
@@ -238,7 +240,7 @@ To derive the desired uStETH/USD feed and make it compatible with the Api3 ecosy
     - Input `PROXY2`: Address of the existing ETH/USD `IApi3ReaderProxy` dAPI.
     - Output: An `IApi3ReaderProxy` contract. This deployed instance of `ProductApi3ReaderProxyV1` reads uStETH/USD.
       - Calculation: `(uStETH/ETH) * (ETH/USD) = uStETH/USD`.
-    - Example command: `NETWORK=your_network PROXY1=0xAddressOfDeployedNormalizedApi3ReaderProxyV1FromStep1 PROXY2=0xAddressOfApi3EthUsdDapi pnpm deploy:ProductApi3ReaderProxyV1`
+    - Example command: `NETWORK=base PROXY1=0xAddressOfDeployedNormalizedApi3ReaderProxyV1FromStep1 PROXY2=0xAddressOfApi3EthUsdDapi pnpm deploy:ProductApi3ReaderProxyV1`
       _(Note: Replace `0xAddressOfDeployedNormalizedApi3ReaderProxyV1FromStep1` with the actual address obtained from the deployment artifact of step 1)._
 
 This scenario highlights how `NormalizedApi3ReaderProxyV1` serves as a crucial bridge, enabling dApps to integrate valuable data from external sources (that may not meet Api3 dAPI listing criteria or are simply outside the current offerings) and combine it with trusted Api3 dAPIs using the standard set of combinator tools.

--- a/contracts/InverseApi3ReaderProxyV1.sol
+++ b/contracts/InverseApi3ReaderProxyV1.sol
@@ -1,29 +1,33 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
+import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
 import "./interfaces/IInverseApi3ReaderProxyV1.sol";
 
 /// @title An immutable proxy contract that inverts the value returned by an
-/// IApi3ReaderProxy data feed
+/// IApi3ReaderProxyV1 data feed
 /// @dev This contract implements the AggregatorV2V3Interface to be compatible
 /// with Chainlink aggregators. This allows the contract to be used as a drop-in
 /// replacement for Chainlink aggregators in existing dApps.
 /// Refer to https://github.com/api3dao/migrate-from-chainlink-to-api3 for more
 /// information about the Chainlink interface implementation.
 contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
-    /// @notice IApi3ReaderProxy contract address
+    /// @notice IApi3ReaderProxyV1 contract address
     address public immutable override proxy;
 
-    /// @param proxy_ IApi3ReaderProxy contract address
+    /// @notice dApp ID of the proxy
+    uint256 public immutable override dappId;
+
+    /// @param proxy_ IApi3ReaderProxyV1 contract address
     constructor(address proxy_) {
         if (proxy_ == address(0)) {
             revert ZeroProxyAddress();
         }
         proxy = proxy_;
+        dappId = IApi3ReaderProxyV1(proxy_).dappId();
     }
 
-    /// @notice Returns the inverted value of the underlying IApi3ReaderProxy
+    /// @notice Returns the inverted value of the underlying IApi3ReaderProxyV1
     /// @dev Calculates `int224(1e36) / baseValue`. The operation will revert if
     /// `baseValue` is zero. If `baseValue` is non-zero but its absolute value is
     /// greater than `1e36`, the result of the integer division will be `0`.
@@ -35,7 +39,7 @@ contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxy(proxy)
+        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxyV1(proxy)
             .read();
 
         if (baseValue == 0) {

--- a/contracts/InverseApi3ReaderProxyV1.sol
+++ b/contracts/InverseApi3ReaderProxyV1.sol
@@ -1,33 +1,34 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
+import "./interfaces/IApi3ReaderProxyWithDappId.sol";
 import "./interfaces/IInverseApi3ReaderProxyV1.sol";
 
 /// @title An immutable proxy contract that inverts the value returned by an
-/// IApi3ReaderProxyV1 data feed
+/// IApi3ReaderProxyWithDappId data feed
 /// @dev This contract implements the AggregatorV2V3Interface to be compatible
 /// with Chainlink aggregators. This allows the contract to be used as a drop-in
 /// replacement for Chainlink aggregators in existing dApps.
 /// Refer to https://github.com/api3dao/migrate-from-chainlink-to-api3 for more
 /// information about the Chainlink interface implementation.
 contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
-    /// @notice IApi3ReaderProxyV1 contract address
+    /// @notice IApi3ReaderProxyWithDappId contract address
     address public immutable override proxy;
 
     /// @notice dApp ID of the proxy
     uint256 public immutable override dappId;
 
-    /// @param proxy_ IApi3ReaderProxyV1 contract address
+    /// @param proxy_ IApi3ReaderProxyWithDappId contract address
     constructor(address proxy_) {
         if (proxy_ == address(0)) {
             revert ZeroProxyAddress();
         }
         proxy = proxy_;
-        dappId = IApi3ReaderProxyV1(proxy_).dappId();
+        dappId = IApi3ReaderProxyWithDappId(proxy_).dappId();
     }
 
-    /// @notice Returns the inverted value of the underlying IApi3ReaderProxyV1
+    /// @notice Returns the inverted value of the underlying
+    /// IApi3ReaderProxyWithDappId
     /// @dev Calculates `int224(1e36) / baseValue`. The operation will revert if
     /// `baseValue` is zero. If `baseValue` is non-zero but its absolute value is
     /// greater than `1e36`, the result of the integer division will be `0`.
@@ -39,8 +40,9 @@ contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxyV1(proxy)
-            .read();
+        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxyWithDappId(
+            proxy
+        ).read();
 
         if (baseValue == 0) {
             revert DivisionByZero();
@@ -99,7 +101,7 @@ contract InverseApi3ReaderProxyV1 is IInverseApi3ReaderProxyV1 {
     }
 
     /// @dev A unique version is chosen to easily check if an unverified
-    /// contract that acts as a Chainlink feed is a InverseApi3ReaderProxyV1
+    /// contract that acts as a Chainlink feed is an InverseApi3ReaderProxyV1
     function version() external pure override returns (uint256) {
         return 4915;
     }

--- a/contracts/NormalizedApi3ReaderProxyV1.sol
+++ b/contracts/NormalizedApi3ReaderProxyV1.sol
@@ -15,6 +15,9 @@ contract NormalizedApi3ReaderProxyV1 is INormalizedApi3ReaderProxyV1 {
     /// @notice Chainlink AggregatorV2V3Interface contract address
     address public immutable override feed;
 
+    /// @notice dApp ID of the proxy
+    uint256 public immutable override dappId;
+
     /// @notice Pre-calculated factor for scaling the feed's value to 18
     /// decimals.
     int256 public immutable scalingFactor;
@@ -24,7 +27,8 @@ contract NormalizedApi3ReaderProxyV1 is INormalizedApi3ReaderProxyV1 {
     bool public immutable isUpscaling;
 
     /// @param feed_ The address of the Chainlink AggregatorV2V3Interface feed
-    constructor(address feed_) {
+    /// @param dappId_ dApp ID of the proxy
+    constructor(address feed_, uint256 dappId_) {
         if (feed_ == address(0)) {
             revert ZeroProxyAddress();
         }
@@ -36,6 +40,7 @@ contract NormalizedApi3ReaderProxyV1 is INormalizedApi3ReaderProxyV1 {
             revert NoNormalizationNeeded();
         }
         feed = feed_;
+        dappId = dappId_;
         uint8 delta = feedDecimals_ > 18
             ? feedDecimals_ - 18
             : 18 - feedDecimals_;

--- a/contracts/PriceCappedApi3ReaderProxyV1.sol
+++ b/contracts/PriceCappedApi3ReaderProxyV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
+import "./interfaces/IApi3ReaderProxyWithDappId.sol";
 import "./interfaces/IPriceCappedApi3ReaderProxyV1.sol";
 
 /**
@@ -21,7 +21,7 @@ import "./interfaces/IPriceCappedApi3ReaderProxyV1.sol";
  * floored at 0 if `lowerBound_` is 0.
  */
 contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
-    /// @notice IApi3ReaderProxyV1 contract address
+    /// @notice IApi3ReaderProxyWithDappId contract address
     address public immutable override proxy;
 
     /// @notice dApp ID of the proxy
@@ -33,7 +33,7 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
     /// @notice The maximum price (inclusive) that this proxy will report.
     int224 public immutable override upperBound;
 
-    /// @param proxy_ IApi3ReaderProxyV1 contract address
+    /// @param proxy_ IApi3ReaderProxyWithDappId contract address
     /// @param lowerBound_ The minimum price (inclusive) this proxy will report
     /// @param upperBound_ The maximum price (inclusive) this proxy will report
     constructor(address proxy_, int224 lowerBound_, int224 upperBound_) {
@@ -47,13 +47,13 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
             revert UpperBoundMustBeGreaterOrEqualToLowerBound();
         }
         proxy = proxy_;
-        dappId = IApi3ReaderProxyV1(proxy_).dappId();
+        dappId = IApi3ReaderProxyWithDappId(proxy_).dappId();
         lowerBound = lowerBound_;
         upperBound = upperBound_;
     }
 
     /// @notice Reads the current value and timestamp from the underlying
-    /// `IApi3ReaderProxyV1` and applies the price bounds.
+    /// `IApi3ReaderProxyWithDappId` and applies the price bounds.
     /// @dev If the `baseValue` from the underlying proxy is less than
     /// `lowerBound`, then `lowerBound` is returned as the `value`. If
     /// `baseValue` is greater than `upperBound`, then `upperBound` is returned.
@@ -67,8 +67,9 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxyV1(proxy)
-            .read();
+        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxyWithDappId(
+            proxy
+        ).read();
 
         timestamp = baseTimestamp;
 
@@ -86,7 +87,7 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
     /// @return True if the base value is less than `lowerBound` or greater
     /// than `upperBound`, false otherwise.
     function isCapped() external view returns (bool) {
-        (int224 baseValue, ) = IApi3ReaderProxyV1(proxy).read();
+        (int224 baseValue, ) = IApi3ReaderProxyWithDappId(proxy).read();
         return baseValue < lowerBound || baseValue > upperBound;
     }
 

--- a/contracts/PriceCappedApi3ReaderProxyV1.sol
+++ b/contracts/PriceCappedApi3ReaderProxyV1.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
+import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
 import "./interfaces/IPriceCappedApi3ReaderProxyV1.sol";
 
 /**
@@ -21,8 +21,11 @@ import "./interfaces/IPriceCappedApi3ReaderProxyV1.sol";
  * floored at 0 if `lowerBound_` is 0.
  */
 contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
-    /// @notice IApi3ReaderProxy contract address
+    /// @notice IApi3ReaderProxyV1 contract address
     address public immutable override proxy;
+
+    /// @notice dApp ID of the proxy
+    uint256 public immutable override dappId;
 
     /// @notice The minimum price (inclusive) that this proxy will report.
     int224 public immutable override lowerBound;
@@ -30,7 +33,7 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
     /// @notice The maximum price (inclusive) that this proxy will report.
     int224 public immutable override upperBound;
 
-    /// @param proxy_ IApi3ReaderProxy contract address
+    /// @param proxy_ IApi3ReaderProxyV1 contract address
     /// @param lowerBound_ The minimum price (inclusive) this proxy will report
     /// @param upperBound_ The maximum price (inclusive) this proxy will report
     constructor(address proxy_, int224 lowerBound_, int224 upperBound_) {
@@ -44,12 +47,13 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
             revert UpperBoundMustBeGreaterOrEqualToLowerBound();
         }
         proxy = proxy_;
+        dappId = IApi3ReaderProxyV1(proxy_).dappId();
         lowerBound = lowerBound_;
         upperBound = upperBound_;
     }
 
     /// @notice Reads the current value and timestamp from the underlying
-    /// `IApi3ReaderProxy` and applies the price bounds.
+    /// `IApi3ReaderProxyV1` and applies the price bounds.
     /// @dev If the `baseValue` from the underlying proxy is less than
     /// `lowerBound`, then `lowerBound` is returned as the `value`. If
     /// `baseValue` is greater than `upperBound`, then `upperBound` is returned.
@@ -63,7 +67,7 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxy(proxy)
+        (int224 baseValue, uint32 baseTimestamp) = IApi3ReaderProxyV1(proxy)
             .read();
 
         timestamp = baseTimestamp;
@@ -82,7 +86,7 @@ contract PriceCappedApi3ReaderProxyV1 is IPriceCappedApi3ReaderProxyV1 {
     /// @return True if the base value is less than `lowerBound` or greater
     /// than `upperBound`, false otherwise.
     function isCapped() external view returns (bool) {
-        (int224 baseValue, ) = IApi3ReaderProxy(proxy).read();
+        (int224 baseValue, ) = IApi3ReaderProxyV1(proxy).read();
         return baseValue < lowerBound || baseValue > upperBound;
     }
 

--- a/contracts/ProductApi3ReaderProxyV1.sol
+++ b/contracts/ProductApi3ReaderProxyV1.sol
@@ -1,25 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
+import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
 import "./interfaces/IProductApi3ReaderProxyV1.sol";
 
 /// @title An immutable proxy contract that is used to read a composition of two
-/// IApi3ReaderProxy data feeds by multiplying their values
+/// IApi3ReaderProxyV1 data feeds by multiplying their values
 /// @dev This contract implements the AggregatorV2V3Interface to be compatible
 /// with Chainlink aggregators. This allows the contract to be used as a drop-in
 /// replacement for Chainlink aggregators in existing dApps.
 /// Refer to https://github.com/api3dao/migrate-from-chainlink-to-api3 for more
 /// information about the Chainlink interface implementation.
 contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
-    /// @notice First IApi3ReaderProxy contract address
+    /// @notice First IApi3ReaderProxyV1 contract address
     address public immutable override proxy1;
 
-    /// @notice Second IApi3ReaderProxy contract address
+    /// @notice Second IApi3ReaderProxyV1 contract address
     address public immutable override proxy2;
 
-    /// @param proxy1_ First IApi3ReaderProxy contract address
-    /// @param proxy2_ Second IApi3ReaderProxy contract address
+    /// @notice The dApp ID of the two proxies
+    uint256 public immutable override dappId;
+
+    /// @param proxy1_ First IApi3ReaderProxyV1 contract address
+    /// @param proxy2_ Second IApi3ReaderProxyV1 contract address
     constructor(address proxy1_, address proxy2_) {
         if (proxy1_ == address(0) || proxy2_ == address(0)) {
             revert ZeroProxyAddress();
@@ -27,12 +30,18 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
         if (proxy1_ == proxy2_) {
             revert SameProxyAddress();
         }
+        uint256 dappId1 = IApi3ReaderProxyV1(proxy1_).dappId();
+        uint256 dappId2 = IApi3ReaderProxyV1(proxy2_).dappId();
+        if (dappId1 != dappId2) {
+            revert DappIdMismatch();
+        }
         proxy1 = proxy1_;
         proxy2 = proxy2_;
+        dappId = dappId1;
     }
 
     /// @notice Returns the current value and timestamp of the rate composition
-    /// between two IApi3ReaderProxy proxies by multiplying their values
+    /// between two IApi3ReaderProxyV1 proxies by multiplying their values
     /// @dev Calculates product as `(int256(value1) * int256(value2)) / 1e18`.
     /// The initial multiplication `int256(value1) * int256(value2)` may revert
     /// on `int256` overflow. The final `int256` result of the full expression
@@ -49,8 +58,8 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (int224 value1, ) = IApi3ReaderProxy(proxy1).read();
-        (int224 value2, ) = IApi3ReaderProxy(proxy2).read();
+        (int224 value1, ) = IApi3ReaderProxyV1(proxy1).read();
+        (int224 value2, ) = IApi3ReaderProxyV1(proxy2).read();
 
         value = int224((int256(value1) * int256(value2)) / 1e18);
         timestamp = uint32(block.timestamp);

--- a/contracts/ProductApi3ReaderProxyV1.sol
+++ b/contracts/ProductApi3ReaderProxyV1.sol
@@ -1,28 +1,28 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
+import "./interfaces/IApi3ReaderProxyWithDappId.sol";
 import "./interfaces/IProductApi3ReaderProxyV1.sol";
 
 /// @title An immutable proxy contract that is used to read a composition of two
-/// IApi3ReaderProxyV1 data feeds by multiplying their values
+/// IApi3ReaderProxyWithDappId data feeds by multiplying their values
 /// @dev This contract implements the AggregatorV2V3Interface to be compatible
 /// with Chainlink aggregators. This allows the contract to be used as a drop-in
 /// replacement for Chainlink aggregators in existing dApps.
 /// Refer to https://github.com/api3dao/migrate-from-chainlink-to-api3 for more
 /// information about the Chainlink interface implementation.
 contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
-    /// @notice First IApi3ReaderProxyV1 contract address
+    /// @notice First IApi3ReaderProxyWithDappId contract address
     address public immutable override proxy1;
 
-    /// @notice Second IApi3ReaderProxyV1 contract address
+    /// @notice Second IApi3ReaderProxyWithDappId contract address
     address public immutable override proxy2;
 
     /// @notice The dApp ID of the two proxies
     uint256 public immutable override dappId;
 
-    /// @param proxy1_ First IApi3ReaderProxyV1 contract address
-    /// @param proxy2_ Second IApi3ReaderProxyV1 contract address
+    /// @param proxy1_ First IApi3ReaderProxyWithDappId contract address
+    /// @param proxy2_ Second IApi3ReaderProxyWithDappId contract address
     constructor(address proxy1_, address proxy2_) {
         if (proxy1_ == address(0) || proxy2_ == address(0)) {
             revert ZeroProxyAddress();
@@ -30,8 +30,8 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
         if (proxy1_ == proxy2_) {
             revert SameProxyAddress();
         }
-        uint256 dappId1 = IApi3ReaderProxyV1(proxy1_).dappId();
-        uint256 dappId2 = IApi3ReaderProxyV1(proxy2_).dappId();
+        uint256 dappId1 = IApi3ReaderProxyWithDappId(proxy1_).dappId();
+        uint256 dappId2 = IApi3ReaderProxyWithDappId(proxy2_).dappId();
         if (dappId1 != dappId2) {
             revert DappIdMismatch();
         }
@@ -41,7 +41,8 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
     }
 
     /// @notice Returns the current value and timestamp of the rate composition
-    /// between two IApi3ReaderProxyV1 proxies by multiplying their values
+    /// between two IApi3ReaderProxyWithDappId proxies by multiplying their
+    /// values
     /// @dev Calculates product as `(int256(value1) * int256(value2)) / 1e18`.
     /// The initial multiplication `int256(value1) * int256(value2)` may revert
     /// on `int256` overflow. The final `int256` result of the full expression
@@ -58,8 +59,8 @@ contract ProductApi3ReaderProxyV1 is IProductApi3ReaderProxyV1 {
         override
         returns (int224 value, uint32 timestamp)
     {
-        (int224 value1, ) = IApi3ReaderProxyV1(proxy1).read();
-        (int224 value2, ) = IApi3ReaderProxyV1(proxy2).read();
+        (int224 value1, ) = IApi3ReaderProxyWithDappId(proxy1).read();
+        (int224 value2, ) = IApi3ReaderProxyWithDappId(proxy2).read();
 
         value = int224((int256(value1) * int256(value2)) / 1e18);
         timestamp = uint32(block.timestamp);

--- a/contracts/adapters/ScaledApi3FeedProxyV1.sol
+++ b/contracts/adapters/ScaledApi3FeedProxyV1.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
+import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
 import "./interfaces/IScaledApi3FeedProxyV1.sol";
 
 /// @title An immutable Chainlink AggregatorV2V3Interface feed contract that
-/// scales the value of an IApi3ReaderProxy data feed to a target number of
+/// scales the value of an IApi3ReaderProxyV1 data feed to a target number of
 /// decimals
 /// @dev This contract reads an `int224` value (assumed to be 18 decimals)
-/// from the underlying `IApi3ReaderProxy` and scales it to `targetDecimals`.
+/// from the underlying `IApi3ReaderProxyV1` and scales it to `targetDecimals`.
 /// The scaling arithmetic uses `int256` for intermediate results, allowing the
 /// scaled value to exceed `int224` limits if upscaling significantly; it will
 /// revert on `int256` overflow.
@@ -16,8 +16,11 @@ import "./interfaces/IScaledApi3FeedProxyV1.sol";
 /// which truncates and may lead to precision loss. Integrators must carefully
 /// consider this potential precision loss for their specific use case.
 contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
-    /// @notice IApi3ReaderProxy contract address
+    /// @notice IApi3ReaderProxyV1 contract address
     address public immutable override proxy;
+
+    /// @notice dApp ID of the proxy
+    uint256 public immutable override dappId;
 
     /// @dev Target decimals for the scaled value.
     uint8 private immutable targetDecimals;
@@ -30,8 +33,8 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
     /// downscaling (divide by `scalingFactor`), to scale to `targetDecimals`.
     bool public immutable isUpscaling;
 
-    /// @param proxy_ IApi3ReaderProxy contract address
-    /// @param targetDecimals_ Decimals used to scale the IApi3ReaderProxy value
+    /// @param proxy_ IApi3ReaderProxyV1 contract address
+    /// @param targetDecimals_ Decimals to scale the IApi3ReaderProxyV1 value
     constructor(address proxy_, uint8 targetDecimals_) {
         if (proxy_ == address(0)) {
             revert ZeroProxyAddress();
@@ -43,6 +46,7 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
             revert NoScalingNeeded();
         }
         proxy = proxy_;
+        dappId = IApi3ReaderProxyV1(proxy_).dappId();
         targetDecimals = targetDecimals_;
         uint8 delta = targetDecimals_ > 18
             ? targetDecimals_ - 18
@@ -88,7 +92,7 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
         revert FunctionIsNotSupported();
     }
 
-    /// @dev Decimals used to scale the IApi3ReaderProxy value
+    /// @dev Decimals used to scale the IApi3ReaderProxyV1 value
     function decimals() external view override returns (uint8) {
         return targetDecimals;
     }
@@ -137,7 +141,7 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
         updatedAt = startedAt;
     }
 
-    /// @notice Reads a value from the underlying `IApi3ReaderProxy` and
+    /// @notice Reads a value from the underlying `IApi3ReaderProxyV1` and
     /// scales it to `targetDecimals`.
     /// @dev Reads from the underlying proxy and applies scaling to
     /// `targetDecimals`. Upscaling uses multiplication; downscaling uses integer
@@ -146,7 +150,7 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
     /// @return value The scaled signed fixed-point value with `targetDecimals`.
     /// @return timestamp The timestamp from the underlying proxy.
     function _read() internal view returns (int256 value, uint32 timestamp) {
-        (int224 proxyValue, uint32 proxyTimestamp) = IApi3ReaderProxy(proxy)
+        (int224 proxyValue, uint32 proxyTimestamp) = IApi3ReaderProxyV1(proxy)
             .read();
 
         value = isUpscaling

--- a/contracts/adapters/ScaledApi3FeedProxyV1.sol
+++ b/contracts/adapters/ScaledApi3FeedProxyV1.sol
@@ -1,14 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.27;
 
-import "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
+import "../interfaces/IApi3ReaderProxyWithDappId.sol";
 import "./interfaces/IScaledApi3FeedProxyV1.sol";
 
 /// @title An immutable Chainlink AggregatorV2V3Interface feed contract that
-/// scales the value of an IApi3ReaderProxyV1 data feed to a target number of
-/// decimals
+/// scales the value of an IApi3ReaderProxyWithDappId data feed to a target
+/// number of decimals
 /// @dev This contract reads an `int224` value (assumed to be 18 decimals)
-/// from the underlying `IApi3ReaderProxyV1` and scales it to `targetDecimals`.
+/// from the underlying `IApi3ReaderProxyWithDappId` and scales it to
+///`targetDecimals`.
 /// The scaling arithmetic uses `int256` for intermediate results, allowing the
 /// scaled value to exceed `int224` limits if upscaling significantly; it will
 /// revert on `int256` overflow.
@@ -16,25 +17,26 @@ import "./interfaces/IScaledApi3FeedProxyV1.sol";
 /// which truncates and may lead to precision loss. Integrators must carefully
 /// consider this potential precision loss for their specific use case.
 contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
-    /// @notice IApi3ReaderProxyV1 contract address
+    /// @notice IApi3ReaderProxyWithDappId contract address
     address public immutable override proxy;
 
     /// @notice dApp ID of the proxy
     uint256 public immutable override dappId;
 
-    /// @dev Target decimals for the scaled value.
-    uint8 private immutable targetDecimals;
-
     /// @notice Pre-calculated factor for scaling the proxy's 18-decimal value
     /// to `targetDecimals`.
-    int256 public immutable scalingFactor;
+    int256 public immutable override scalingFactor;
 
     /// @notice True if upscaling (multiply by `scalingFactor`), false if
     /// downscaling (divide by `scalingFactor`), to scale to `targetDecimals`.
-    bool public immutable isUpscaling;
+    bool public immutable override isUpscaling;
 
-    /// @param proxy_ IApi3ReaderProxyV1 contract address
-    /// @param targetDecimals_ Decimals to scale the IApi3ReaderProxyV1 value
+    /// @dev Target decimals for the scaled value.
+    uint8 private immutable targetDecimals;
+
+    /// @param proxy_ IApi3ReaderProxyWithDappId contract address
+    /// @param targetDecimals_ Decimals to scale the IApi3ReaderProxyWithDappId
+    /// value
     constructor(address proxy_, uint8 targetDecimals_) {
         if (proxy_ == address(0)) {
             revert ZeroProxyAddress();
@@ -46,7 +48,7 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
             revert NoScalingNeeded();
         }
         proxy = proxy_;
-        dappId = IApi3ReaderProxyV1(proxy_).dappId();
+        dappId = IApi3ReaderProxyWithDappId(proxy_).dappId();
         targetDecimals = targetDecimals_;
         uint8 delta = targetDecimals_ > 18
             ? targetDecimals_ - 18
@@ -92,7 +94,7 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
         revert FunctionIsNotSupported();
     }
 
-    /// @dev Decimals used to scale the IApi3ReaderProxyV1 value
+    /// @dev Decimals used to scale the IApi3ReaderProxyWithDappId value
     function decimals() external view override returns (uint8) {
         return targetDecimals;
     }
@@ -141,8 +143,8 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
         updatedAt = startedAt;
     }
 
-    /// @notice Reads a value from the underlying `IApi3ReaderProxyV1` and
-    /// scales it to `targetDecimals`.
+    /// @notice Reads a value from the underlying `IApi3ReaderProxyWithDappId`
+    /// and scales it to `targetDecimals`.
     /// @dev Reads from the underlying proxy and applies scaling to
     /// `targetDecimals`. Upscaling uses multiplication; downscaling uses integer
     /// division (which truncates). All scaling arithmetic is performed using
@@ -150,8 +152,9 @@ contract ScaledApi3FeedProxyV1 is IScaledApi3FeedProxyV1 {
     /// @return value The scaled signed fixed-point value with `targetDecimals`.
     /// @return timestamp The timestamp from the underlying proxy.
     function _read() internal view returns (int256 value, uint32 timestamp) {
-        (int224 proxyValue, uint32 proxyTimestamp) = IApi3ReaderProxyV1(proxy)
-            .read();
+        (int224 proxyValue, uint32 proxyTimestamp) = IApi3ReaderProxyWithDappId(
+            proxy
+        ).read();
 
         value = isUpscaling
             ? proxyValue * scalingFactor

--- a/contracts/adapters/interfaces/IScaledApi3FeedProxyV1.sol
+++ b/contracts/adapters/interfaces/IScaledApi3FeedProxyV1.sol
@@ -17,4 +17,6 @@ interface IScaledApi3FeedProxyV1 is AggregatorV2V3Interface {
     function scalingFactor() external view returns (int256);
 
     function isUpscaling() external view returns (bool);
+
+    function dappId() external view returns (uint256);
 }

--- a/contracts/interfaces/IApi3ReaderProxyWithDappId.sol
+++ b/contracts/interfaces/IApi3ReaderProxyWithDappId.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
+
+interface IApi3ReaderProxyWithDappId is IApi3ReaderProxy {
+    function dappId() external view returns (uint256);
+}

--- a/contracts/interfaces/IInverseApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/IInverseApi3ReaderProxyV1.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "../vendor/@chainlink/contracts@1.2.0/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol";
+import "./IApi3ReaderProxyWithDappId.sol";
 
 interface IInverseApi3ReaderProxyV1 is
-    IApi3ReaderProxy,
+    IApi3ReaderProxyWithDappId,
     AggregatorV2V3Interface
 {
     error ZeroProxyAddress();
@@ -14,7 +14,5 @@ interface IInverseApi3ReaderProxyV1 is
 
     error FunctionIsNotSupported();
 
-    function proxy() external view returns (address proxy);
-
-    function dappId() external view returns (uint256);
+    function proxy() external view returns (address);
 }

--- a/contracts/interfaces/IInverseApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/IInverseApi3ReaderProxyV1.sol
@@ -15,4 +15,6 @@ interface IInverseApi3ReaderProxyV1 is
     error FunctionIsNotSupported();
 
     function proxy() external view returns (address proxy);
+
+    function dappId() external view returns (uint256);
 }

--- a/contracts/interfaces/INormalizedApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/INormalizedApi3ReaderProxyV1.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "../vendor/@chainlink/contracts@1.2.0/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol";
+import "./IApi3ReaderProxyWithDappId.sol";
 
 interface INormalizedApi3ReaderProxyV1 is
-    IApi3ReaderProxy,
+    IApi3ReaderProxyWithDappId,
     AggregatorV2V3Interface
 {
     error ZeroProxyAddress();
@@ -16,9 +16,7 @@ interface INormalizedApi3ReaderProxyV1 is
 
     error FunctionIsNotSupported();
 
-    function feed() external view returns (address feed);
-
-    function dappId() external view returns (uint256);
+    function feed() external view returns (address);
 
     function scalingFactor() external view returns (int256);
 

--- a/contracts/interfaces/INormalizedApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/INormalizedApi3ReaderProxyV1.sol
@@ -18,6 +18,8 @@ interface INormalizedApi3ReaderProxyV1 is
 
     function feed() external view returns (address feed);
 
+    function dappId() external view returns (uint256);
+
     function scalingFactor() external view returns (int256);
 
     function isUpscaling() external view returns (bool);

--- a/contracts/interfaces/IPriceCappedApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/IPriceCappedApi3ReaderProxyV1.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "../vendor/@chainlink/contracts@1.2.0/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol";
+import "./IApi3ReaderProxyWithDappId.sol";
 
 interface IPriceCappedApi3ReaderProxyV1 is
-    IApi3ReaderProxy,
+    IApi3ReaderProxyWithDappId,
     AggregatorV2V3Interface
 {
     error ZeroProxyAddress();
@@ -16,13 +16,11 @@ interface IPriceCappedApi3ReaderProxyV1 is
 
     error FunctionIsNotSupported();
 
-    function proxy() external view returns (address proxy);
+    function proxy() external view returns (address);
 
-    function dappId() external view returns (uint256);
+    function lowerBound() external view returns (int224);
 
-    function lowerBound() external view returns (int224 lowerBound);
-
-    function upperBound() external view returns (int224 upperBound);
+    function upperBound() external view returns (int224);
 
     function isCapped() external view returns (bool);
 }

--- a/contracts/interfaces/IPriceCappedApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/IPriceCappedApi3ReaderProxyV1.sol
@@ -18,6 +18,8 @@ interface IPriceCappedApi3ReaderProxyV1 is
 
     function proxy() external view returns (address proxy);
 
+    function dappId() external view returns (uint256);
+
     function lowerBound() external view returns (int224 lowerBound);
 
     function upperBound() external view returns (int224 upperBound);

--- a/contracts/interfaces/IProductApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/IProductApi3ReaderProxyV1.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "../vendor/@chainlink/contracts@1.2.0/src/v0.8/shared/interfaces/AggregatorV2V3Interface.sol";
+import "./IApi3ReaderProxyWithDappId.sol";
 
 interface IProductApi3ReaderProxyV1 is
-    IApi3ReaderProxy,
+    IApi3ReaderProxyWithDappId,
     AggregatorV2V3Interface
 {
     error ZeroProxyAddress();
@@ -18,9 +18,7 @@ interface IProductApi3ReaderProxyV1 is
 
     error FunctionIsNotSupported();
 
-    function proxy1() external view returns (address proxy1);
+    function proxy1() external view returns (address);
 
-    function proxy2() external view returns (address proxy2);
-
-    function dappId() external view returns (uint256);
+    function proxy2() external view returns (address);
 }

--- a/contracts/interfaces/IProductApi3ReaderProxyV1.sol
+++ b/contracts/interfaces/IProductApi3ReaderProxyV1.sol
@@ -12,6 +12,8 @@ interface IProductApi3ReaderProxyV1 is
 
     error SameProxyAddress();
 
+    error DappIdMismatch();
+
     error ZeroDenominator();
 
     error FunctionIsNotSupported();
@@ -19,4 +21,6 @@ interface IProductApi3ReaderProxyV1 is
     function proxy1() external view returns (address proxy1);
 
     function proxy2() external view returns (address proxy2);
+
+    function dappId() external view returns (uint256);
 }

--- a/contracts/test/AccessControlRegistry.sol
+++ b/contracts/test/AccessControlRegistry.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
-
-import "@api3/contracts/access/AccessControlRegistry.sol";

--- a/contracts/test/Api3ReaderProxyV1.sol
+++ b/contracts/test/Api3ReaderProxyV1.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.27;
-
-import "@api3/contracts/api3-server-v1/proxies/Api3ReaderProxyV1.sol";

--- a/contracts/test/Api3ServerV1.sol
+++ b/contracts/test/Api3ServerV1.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
-
-import "@api3/contracts/api3-server-v1/Api3ServerV1.sol";

--- a/contracts/test/Api3ServerV1OevExtension.sol
+++ b/contracts/test/Api3ServerV1OevExtension.sol
@@ -1,4 +1,0 @@
-// SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
-
-import "@api3/contracts/api3-server-v1/Api3ServerV1OevExtension.sol";

--- a/contracts/test/MockApi3ReaderProxyV1.sol
+++ b/contracts/test/MockApi3ReaderProxyV1.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.27;
+
+import {
+    IApi3ReaderProxyV1
+} from "@api3/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol";
+
+/// @title A mock contract for IApi3ReaderProxyV1
+/// @dev This mock implements the minimal functions required for testing the
+/// data-feed-proxy-combinators contracts. Other functions will revert.
+contract MockApi3ReaderProxyV1 is IApi3ReaderProxyV1 {
+    /// @notice The dApp ID of the mock proxy.
+    uint256 public immutable override dappId;
+    /// @notice The mock value to be returned by read().
+    int224 private _value;
+    /// @notice The mock timestamp to be returned by read().
+    uint32 private _timestamp;
+
+    constructor(uint256 dappId_, int224 value_, uint32 timestamp_) {
+        dappId = dappId_;
+        _value = value_;
+        _timestamp = timestamp_;
+    }
+
+    function read() public view override returns (int224, uint32) {
+        return (_value, _timestamp);
+    }
+
+    function update(int224 value, uint32 timestamp) external {
+        _value = value;
+        _timestamp = timestamp;
+    }
+
+    // --- Stubbed functions from IApi3ReaderProxyV1 that are not used by combinators ---
+
+    function initialize(address) external pure override {
+        revert("Mock: Not implemented");
+    }
+
+    function api3ServerV1() external pure override returns (address) {
+        revert("Mock: Not implemented");
+    }
+
+    function api3ServerV1OevExtension()
+        external
+        pure
+        override
+        returns (address)
+    {
+        revert("Mock: Not implemented");
+    }
+
+    function dapiName() external pure override returns (bytes32) {
+        revert("Mock: Not implemented");
+    }
+}

--- a/deploy/001_deploy_InverseApi3ReaderProxyV1.ts
+++ b/deploy/001_deploy_InverseApi3ReaderProxyV1.ts
@@ -3,6 +3,7 @@ import type { DeploymentsExtension } from 'hardhat-deploy/types';
 
 import { getDeploymentName } from '../src';
 import * as testUtils from '../test/test-utils';
+import { IApi3ReaderProxyWithDappId__factory } from '../typechain-types';
 
 export const CONTRACT_NAME = 'InverseApi3ReaderProxyV1';
 
@@ -42,7 +43,15 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
   }
   log(`Proxy address: ${proxyAddress}`);
 
-  // TODO: check that proxyAddress returns a dappId
+  if (!isLocalNetwork) {
+    try {
+      const proxy = IApi3ReaderProxyWithDappId__factory.connect(proxyAddress, ethers.provider);
+      const dappId = await proxy.dappId();
+      log(`Proxy dappId: ${dappId}`);
+    } catch {
+      throw new Error(`Failed to read dappId from proxy at ${proxyAddress}`);
+    }
+  }
 
   const confirmations = isLocalNetwork ? 1 : 5;
   log(`Deployment confirmations: ${confirmations}`);

--- a/deploy/003_deploy_ProductApi3ReaderProxyV1.ts
+++ b/deploy/003_deploy_ProductApi3ReaderProxyV1.ts
@@ -1,8 +1,27 @@
 import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+import type { DeploymentsExtension } from 'hardhat-deploy/types';
 
 import { getDeploymentName } from '../src';
+import * as testUtils from '../test/test-utils';
 
 export const CONTRACT_NAME = 'ProductApi3ReaderProxyV1';
+
+const deployMockApi3ReaderProxyV1 = async (
+  deployments: DeploymentsExtension,
+  deployerAddress: string,
+  dappId: string
+) => {
+  const { address } = await deployments.deploy('MockApi3ReaderProxyV1', {
+    from: deployerAddress,
+    args: [
+      dappId,
+      '2000000000000000000000', // A mock value (2000e18)
+      Math.floor(Date.now() / 1000), // A mock timestamp
+    ],
+    log: true,
+  });
+  return address;
+};
 
 module.exports = async (hre: HardhatRuntimeEnvironment) => {
   const { getUnnamedAccounts, deployments, ethers, network, run } = hre;
@@ -14,7 +33,12 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
   }
   log(`Deployer address: ${deployerAddress}`);
 
-  const proxy1Address = process.env.PROXY1;
+  const isLocalNetwork = network.name === 'hardhat' || network.name === 'localhost';
+
+  const dappId = testUtils.generateRandomBytes32();
+  const proxy1Address = isLocalNetwork
+    ? await deployMockApi3ReaderProxyV1(deployments, deployerAddress, dappId)
+    : process.env.PROXY1;
   if (!proxy1Address) {
     throw new Error('PROXY1 environment variable not set. Please provide the address of the first proxy contract.');
   }
@@ -23,7 +47,14 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
   }
   log(`Proxy 1 address: ${proxy1Address}`);
 
-  const proxy2Address = process.env.PROXY2;
+  // Sleep for 1 sec when deploying to local network in order to generate a different proxy address
+  if (isLocalNetwork) {
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  const proxy2Address = isLocalNetwork
+    ? await deployMockApi3ReaderProxyV1(deployments, deployerAddress, dappId)
+    : process.env.PROXY2;
   if (!proxy2Address) {
     throw new Error('PROXY2 environment variable not set. Please provide the address of the second proxy contract.');
   }
@@ -31,8 +62,6 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
     throw new Error(`Invalid address provided for PROXY2: ${proxy2Address}`);
   }
   log(`Proxy 2 address: ${proxy2Address}`);
-
-  const isLocalNetwork = network.name === 'hardhat' || network.name === 'localhost';
 
   const confirmations = isLocalNetwork ? 1 : 5;
   log(`Deployment confirmations: ${confirmations}`);

--- a/deploy/004_deploy_ScaledApi3FeedProxyV1.ts
+++ b/deploy/004_deploy_ScaledApi3FeedProxyV1.ts
@@ -3,6 +3,7 @@ import type { DeploymentsExtension } from 'hardhat-deploy/types';
 
 import { getDeploymentName } from '../src';
 import * as testUtils from '../test/test-utils';
+import { IApi3ReaderProxyWithDappId__factory } from '../typechain-types';
 
 export const CONTRACT_NAME = 'ScaledApi3FeedProxyV1';
 
@@ -47,6 +48,16 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
     throw new Error(`Invalid address provided for PROXY: ${proxyAddress}`);
   }
   log(`Proxy address: ${proxyAddress}`);
+
+  if (!isLocalNetwork) {
+    try {
+      const proxy = IApi3ReaderProxyWithDappId__factory.connect(proxyAddress, ethers.provider);
+      const dappId = await proxy.dappId();
+      log(`Proxy dappId: ${dappId}`);
+    } catch {
+      throw new Error(`Failed to read dappId from proxy at ${proxyAddress}`);
+    }
+  }
 
   const confirmations = isLocalNetwork ? 1 : 5;
   log(`Deployment confirmations: ${confirmations}`);

--- a/deploy/005_deploy_PriceCappedApi3ReaderProxyV1.ts
+++ b/deploy/005_deploy_PriceCappedApi3ReaderProxyV1.ts
@@ -3,6 +3,7 @@ import type { DeploymentsExtension } from 'hardhat-deploy/types';
 
 import { getDeploymentName } from '../src';
 import * as testUtils from '../test/test-utils';
+import { IApi3ReaderProxyWithDappId__factory } from '../typechain-types';
 
 export const CONTRACT_NAME = 'PriceCappedApi3ReaderProxyV1';
 
@@ -41,6 +42,16 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
     throw new Error(`Invalid address provided for PROXY: ${proxyAddress}`);
   }
   log(`Proxy address: ${proxyAddress}`);
+
+  if (!isLocalNetwork) {
+    try {
+      const proxy = IApi3ReaderProxyWithDappId__factory.connect(proxyAddress, ethers.provider);
+      const dappId = await proxy.dappId();
+      log(`Proxy dappId: ${dappId}`);
+    } catch {
+      throw new Error(`Failed to read dappId from proxy at ${proxyAddress}`);
+    }
+  }
 
   const lowerBound = process.env.LOWER_BOUND ? BigInt(process.env.LOWER_BOUND) : 0n; // Defaults to 0
   log(`Using lower bound: ${lowerBound.toString()}`);

--- a/test/PriceCappedApi3ReaderProxyV1.sol.ts
+++ b/test/PriceCappedApi3ReaderProxyV1.sol.ts
@@ -7,60 +7,17 @@ import * as testUtils from './test-utils';
 
 describe('PriceCappedApi3ReaderProxyV1', function () {
   async function deploy() {
-    const roleNames = ['deployer', 'manager', 'airnode', 'auctioneer', 'searcher'];
+    const roleNames = ['deployer'];
     const accounts = await ethers.getSigners();
     const roles: Record<string, HardhatEthersSigner> = roleNames.reduce((acc, roleName, index) => {
       return { ...acc, [roleName]: accounts[index] };
     }, {});
 
-    const accessControlRegistryFactory = await ethers.getContractFactory('AccessControlRegistry', roles.deployer);
-    const accessControlRegistry = await accessControlRegistryFactory.deploy();
-
-    const api3ServerV1Factory = await ethers.getContractFactory('Api3ServerV1', roles.deployer);
-    const api3ServerV1 = await api3ServerV1Factory.deploy(
-      accessControlRegistry.getAddress(),
-      'Api3ServerV1 admin',
-      roles.manager!.address
-    );
-
-    const api3ServerV1OevExtensionAdminRoleDescription = 'Api3ServerV1OevExtension admin';
-    const api3ServerV1OevExtensionFactory = await ethers.getContractFactory('Api3ServerV1OevExtension', roles.deployer);
-    const api3ServerV1OevExtension = await api3ServerV1OevExtensionFactory.deploy(
-      accessControlRegistry.getAddress(),
-      api3ServerV1OevExtensionAdminRoleDescription,
-      roles.manager!.address,
-      api3ServerV1.getAddress()
-    );
-
-    const dapiName = ethers.encodeBytes32String('DAI/USD');
-    const dappId = 1;
-
-    const api3ReaderProxyV1Factory = await ethers.getContractFactory('Api3ReaderProxyV1', roles.deployer);
-    const api3ReaderProxyV1 = await api3ReaderProxyV1Factory.deploy(
-      api3ServerV1OevExtension.getAddress(),
-      dapiName,
-      dappId
-    );
-
-    const endpointId = testUtils.generateRandomBytes32();
-    const templateParameters = testUtils.generateRandomBytes();
-    const templateId = ethers.keccak256(ethers.solidityPacked(['bytes32', 'bytes'], [endpointId, templateParameters]));
-    const beaconId = ethers.keccak256(
-      ethers.solidityPacked(['address', 'bytes32'], [roles.airnode!.address, templateId])
-    );
-    await api3ServerV1.connect(roles.manager).setDapiName(dapiName, beaconId);
-
-    const baseBeaconValue = ethers.parseEther('1.0001');
-    const baseBeaconTimestamp = await helpers.time.latest();
-    const data = ethers.AbiCoder.defaultAbiCoder().encode(['int256'], [baseBeaconValue]);
-    const signature = await testUtils.signData(roles.airnode! as any, templateId, baseBeaconTimestamp, data);
-    await api3ServerV1.updateBeaconWithSignedData(
-      roles.airnode!.address,
-      templateId,
-      baseBeaconTimestamp,
-      data,
-      signature
-    );
+    const dappId = testUtils.generateRandomBytes32();
+    const beaconValue = ethers.parseEther('1.0001');
+    const beaconTimestamp = await helpers.time.latest();
+    const mockApi3ReaderProxyV1Factory = await ethers.getContractFactory('MockApi3ReaderProxyV1', roles.deployer);
+    const proxy = await mockApi3ReaderProxyV1Factory.deploy(dappId, beaconValue, beaconTimestamp);
 
     const lowerBound = ethers.parseEther('0.9995');
     const upperBound = ethers.parseEther('1.0005');
@@ -70,18 +27,16 @@ describe('PriceCappedApi3ReaderProxyV1', function () {
       roles.deployer
     );
     const priceCappedApi3ReaderProxyV1 = await priceCappedApi3ReaderProxyV1Factory.deploy(
-      await api3ReaderProxyV1.getAddress(),
+      await proxy.getAddress(),
       lowerBound,
       upperBound
     );
 
     return {
-      api3ServerV1,
-      api3ReaderProxyV1,
+      proxy,
       priceCappedApi3ReaderProxyV1,
       lowerBound,
       upperBound,
-      templateId,
       roles,
     };
   }
@@ -91,21 +46,21 @@ describe('PriceCappedApi3ReaderProxyV1', function () {
       context('lowerBound is not negative', function () {
         context('upperBound is greater or  equal to lowerBound', function () {
           it('constructs', async function () {
-            const { api3ReaderProxyV1, priceCappedApi3ReaderProxyV1, lowerBound, upperBound } =
-              await helpers.loadFixture(deploy);
-            expect(await priceCappedApi3ReaderProxyV1.proxy()).to.equal(await api3ReaderProxyV1.getAddress());
+            const { proxy, priceCappedApi3ReaderProxyV1, lowerBound, upperBound } = await helpers.loadFixture(deploy);
+            expect(await priceCappedApi3ReaderProxyV1.proxy()).to.equal(await proxy.getAddress());
+            expect(await priceCappedApi3ReaderProxyV1.dappId()).to.equal(await proxy.dappId());
             expect(await priceCappedApi3ReaderProxyV1.lowerBound()).to.equal(lowerBound);
             expect(await priceCappedApi3ReaderProxyV1.upperBound()).to.equal(upperBound);
           });
         });
         context('upperBound is less than lowerBound', function () {
           it('reverts', async function () {
-            const { api3ReaderProxyV1, lowerBound, upperBound, roles } = await helpers.loadFixture(deploy);
+            const { proxy, lowerBound, upperBound, roles } = await helpers.loadFixture(deploy);
             const priceCappedApi3ReaderProxyV1 = await ethers.getContractFactory(
               'PriceCappedApi3ReaderProxyV1',
               roles.deployer
             );
-            await expect(priceCappedApi3ReaderProxyV1.deploy(api3ReaderProxyV1, upperBound, lowerBound))
+            await expect(priceCappedApi3ReaderProxyV1.deploy(proxy, upperBound, lowerBound))
               .to.be.revertedWithCustomError(priceCappedApi3ReaderProxyV1, 'UpperBoundMustBeGreaterOrEqualToLowerBound')
               .withArgs();
           });
@@ -113,12 +68,12 @@ describe('PriceCappedApi3ReaderProxyV1', function () {
       });
       context('lowerBound is negative', function () {
         it('reverts', async function () {
-          const { api3ReaderProxyV1, upperBound, roles } = await helpers.loadFixture(deploy);
+          const { proxy, upperBound, roles } = await helpers.loadFixture(deploy);
           const priceCappedApi3ReaderProxyV1 = await ethers.getContractFactory(
             'PriceCappedApi3ReaderProxyV1',
             roles.deployer
           );
-          await expect(priceCappedApi3ReaderProxyV1.deploy(api3ReaderProxyV1, ethers.parseEther('-0.9995'), upperBound))
+          await expect(priceCappedApi3ReaderProxyV1.deploy(proxy, ethers.parseEther('-0.9995'), upperBound))
             .to.be.revertedWithCustomError(priceCappedApi3ReaderProxyV1, 'LowerBoundMustBeNonNegative')
             .withArgs();
         });
@@ -140,48 +95,26 @@ describe('PriceCappedApi3ReaderProxyV1', function () {
 
   describe('read', function () {
     it('reads the capped rate', async function () {
-      const {
-        api3ServerV1,
-        api3ReaderProxyV1,
-        priceCappedApi3ReaderProxyV1,
-        templateId,
-        lowerBound,
-        upperBound,
-        roles,
-      } = await helpers.loadFixture(deploy);
+      const { proxy, priceCappedApi3ReaderProxyV1, lowerBound, upperBound } = await helpers.loadFixture(deploy);
       const dataFeed = await priceCappedApi3ReaderProxyV1.read();
 
-      const [value, timestamp] = await api3ReaderProxyV1.read();
+      const [value, timestamp] = await proxy.read();
       expect(dataFeed.value).to.equal(value);
       expect(dataFeed.timestamp).to.equal(timestamp);
 
-      let data = ethers.AbiCoder.defaultAbiCoder().encode(['int256'], [ethers.parseEther('0.9991')]);
-      let beaconTimestamp = await helpers.time.latest();
-      let signature = await testUtils.signData(roles.airnode! as any, templateId, beaconTimestamp, data);
-      await api3ServerV1.updateBeaconWithSignedData(
-        roles.airnode!.address,
-        templateId,
-        beaconTimestamp,
-        data,
-        signature
-      );
+      let newTimestamp = await helpers.time.latest();
+      await proxy.update(ethers.parseEther('0.9991'), newTimestamp);
+
       const cappedToLowerBoundDataFeed = await priceCappedApi3ReaderProxyV1.read();
       expect(cappedToLowerBoundDataFeed.value).to.equal(lowerBound);
-      expect(cappedToLowerBoundDataFeed.timestamp).to.equal(beaconTimestamp);
+      expect(cappedToLowerBoundDataFeed.timestamp).to.equal(newTimestamp);
 
-      data = ethers.AbiCoder.defaultAbiCoder().encode(['int256'], [ethers.parseEther('1.0006')]);
-      beaconTimestamp = await helpers.time.latest();
-      signature = await testUtils.signData(roles.airnode! as any, templateId, beaconTimestamp, data);
-      await api3ServerV1.updateBeaconWithSignedData(
-        roles.airnode!.address,
-        templateId,
-        beaconTimestamp,
-        data,
-        signature
-      );
+      newTimestamp = await helpers.time.latest();
+      await proxy.update(ethers.parseEther('1.0006'), newTimestamp);
+
       const cappedToUpperBoundDataFeed = await priceCappedApi3ReaderProxyV1.read();
       expect(cappedToUpperBoundDataFeed.value).to.equal(upperBound);
-      expect(cappedToUpperBoundDataFeed.timestamp).to.equal(beaconTimestamp);
+      expect(cappedToUpperBoundDataFeed.timestamp).to.equal(newTimestamp);
     });
   });
 

--- a/test/ProductApi3ReaderProxyV1.sol.ts
+++ b/test/ProductApi3ReaderProxyV1.sol.ts
@@ -7,119 +7,38 @@ import * as testUtils from './test-utils';
 
 describe('ProductApi3ReaderProxyV1', function () {
   async function deploy() {
-    const roleNames = ['deployer', 'manager', 'airnode', 'auctioneer', 'searcher'];
+    const roleNames = ['deployer'];
     const accounts = await ethers.getSigners();
     const roles: Record<string, HardhatEthersSigner> = roleNames.reduce((acc, roleName, index) => {
       return { ...acc, [roleName]: accounts[index] };
     }, {});
 
-    const accessControlRegistryFactory = await ethers.getContractFactory('AccessControlRegistry', roles.deployer);
-    const accessControlRegistry = await accessControlRegistryFactory.deploy();
-
-    const api3ServerV1Factory = await ethers.getContractFactory('Api3ServerV1', roles.deployer);
-    const api3ServerV1 = await api3ServerV1Factory.deploy(
-      accessControlRegistry.getAddress(),
-      'Api3ServerV1 admin',
-      roles.manager!.address
-    );
-
-    const api3ServerV1OevExtensionAdminRoleDescription = 'Api3ServerV1OevExtension admin';
-    const api3ServerV1OevExtensionFactory = await ethers.getContractFactory('Api3ServerV1OevExtension', roles.deployer);
-    const api3ServerV1OevExtension = await api3ServerV1OevExtensionFactory.deploy(
-      accessControlRegistry.getAddress(),
-      api3ServerV1OevExtensionAdminRoleDescription,
-      roles.manager!.address,
-      api3ServerV1.getAddress()
-    );
-
-    const api3ReaderProxyV1Factory = await ethers.getContractFactory('Api3ReaderProxyV1', roles.deployer);
-
-    const dappId = 1;
-    const dapiNameEthUsd = ethers.encodeBytes32String('ETH/USD');
-    const api3ReaderProxyV1EthUsd = await api3ReaderProxyV1Factory.deploy(
-      api3ServerV1OevExtension.getAddress(),
-      dapiNameEthUsd,
-      dappId
-    );
-    const dapiNameSolEth = ethers.encodeBytes32String('SOL/ETH');
-    const api3ReaderProxyV1SolEth = await api3ReaderProxyV1Factory.deploy(
-      api3ServerV1OevExtension.getAddress(),
-      dapiNameSolEth,
-      dappId
-    );
+    const dappId = testUtils.generateRandomBytes32();
+    const mockApi3ReaderProxyV1Factory = await ethers.getContractFactory('MockApi3ReaderProxyV1', roles.deployer);
+    const beaconValue1 = ethers.parseEther('1824.97');
+    const beaconTimestamp1 = await helpers.time.latest();
+    const proxy1 = await mockApi3ReaderProxyV1Factory.deploy(dappId, beaconValue1, beaconTimestamp1);
+    const beaconValue2 = ethers.parseEther('0.08202');
+    const beaconTimestamp2 = await helpers.time.latest();
+    const proxy2 = await mockApi3ReaderProxyV1Factory.deploy(dappId, beaconValue2, beaconTimestamp2);
 
     const productApi3ReaderProxyV1Factory = await ethers.getContractFactory('ProductApi3ReaderProxyV1', roles.deployer);
 
-    const productApi3ReaderProxyV1SolUsd = await productApi3ReaderProxyV1Factory.deploy(
-      api3ReaderProxyV1EthUsd.getAddress(),
-      api3ReaderProxyV1SolEth.getAddress()
+    const productApi3ReaderProxyV1 = await productApi3ReaderProxyV1Factory.deploy(
+      proxy1.getAddress(),
+      proxy2.getAddress()
     );
 
-    const productApi3ReaderProxyV1EthSol = await productApi3ReaderProxyV1Factory.deploy(
-      api3ReaderProxyV1EthUsd.getAddress(),
-      productApi3ReaderProxyV1SolUsd.getAddress()
-    );
-
-    const endpointIdEthUsd = testUtils.generateRandomBytes32();
-    const templateParametersEthUsd = testUtils.generateRandomBytes();
-    const templateIdEthUsd = ethers.keccak256(
-      ethers.solidityPacked(['bytes32', 'bytes'], [endpointIdEthUsd, templateParametersEthUsd])
-    );
-    const beaconIdEthUsd = ethers.keccak256(
-      ethers.solidityPacked(['address', 'bytes32'], [roles.airnode!.address, templateIdEthUsd])
-    );
-    await api3ServerV1.connect(roles.manager).setDapiName(dapiNameEthUsd, beaconIdEthUsd);
-
-    const baseBeaconValueEthUsd = ethers.parseEther('1824.97');
-    const baseBeaconTimestampEthUsd = await helpers.time.latest();
-    const dataEthUsd = ethers.AbiCoder.defaultAbiCoder().encode(['int256'], [baseBeaconValueEthUsd]);
-    const signatureEthUsd = await testUtils.signData(
-      roles.airnode! as any,
-      templateIdEthUsd,
-      baseBeaconTimestampEthUsd,
-      dataEthUsd
-    );
-    await api3ServerV1.updateBeaconWithSignedData(
-      roles.airnode!.address,
-      templateIdEthUsd,
-      baseBeaconTimestampEthUsd,
-      dataEthUsd,
-      signatureEthUsd
-    );
-
-    const endpointIdSolEth = testUtils.generateRandomBytes32();
-    const templateParametersSolEth = testUtils.generateRandomBytes();
-    const templateIdSolEth = ethers.keccak256(
-      ethers.solidityPacked(['bytes32', 'bytes'], [endpointIdSolEth, templateParametersSolEth])
-    );
-    const beaconIdSolEth = ethers.keccak256(
-      ethers.solidityPacked(['address', 'bytes32'], [roles.airnode!.address, templateIdSolEth])
-    );
-    await api3ServerV1.connect(roles.manager).setDapiName(dapiNameSolEth, beaconIdSolEth);
-
-    const baseBeaconValueSolEth = ethers.parseEther('0.08202');
-    const baseBeaconTimestampSolEth = await helpers.time.latest();
-    const dataSolEth = ethers.AbiCoder.defaultAbiCoder().encode(['int256'], [baseBeaconValueSolEth]);
-    const signatureSolEth = await testUtils.signData(
-      roles.airnode! as any,
-      templateIdSolEth,
-      baseBeaconTimestampSolEth,
-      dataSolEth
-    );
-    await api3ServerV1.updateBeaconWithSignedData(
-      roles.airnode!.address,
-      templateIdSolEth,
-      baseBeaconTimestampSolEth,
-      dataSolEth,
-      signatureSolEth
+    const productApi3ReaderProxyV1Compound = await productApi3ReaderProxyV1Factory.deploy(
+      proxy1.getAddress(),
+      productApi3ReaderProxyV1.getAddress()
     );
 
     return {
-      api3ReaderProxyV1EthUsd,
-      api3ReaderProxyV1SolEth,
-      api3ServerV1,
-      productApi3ReaderProxyV1EthSol,
-      productApi3ReaderProxyV1SolUsd,
+      proxy1,
+      proxy2,
+      productApi3ReaderProxyV1,
+      productApi3ReaderProxyV1Compound,
       roles,
     };
   }
@@ -129,33 +48,28 @@ describe('ProductApi3ReaderProxyV1', function () {
       context('proxy2 is not zero address', function () {
         context('proxy1 is not the same as proxy2', function () {
           it('constructs', async function () {
-            const {
-              productApi3ReaderProxyV1SolUsd,
-              productApi3ReaderProxyV1EthSol,
-              api3ReaderProxyV1EthUsd,
-              api3ReaderProxyV1SolEth,
-            } = await helpers.loadFixture(deploy);
-            expect(await productApi3ReaderProxyV1SolUsd.proxy1()).to.equal(await api3ReaderProxyV1EthUsd.getAddress());
-            expect(await productApi3ReaderProxyV1SolUsd.proxy2()).to.equal(await api3ReaderProxyV1SolEth.getAddress());
-            expect(await productApi3ReaderProxyV1EthSol.proxy1()).to.equal(await api3ReaderProxyV1EthUsd.getAddress());
-            expect(await productApi3ReaderProxyV1EthSol.proxy2()).to.equal(
-              await productApi3ReaderProxyV1SolUsd.getAddress()
+            const { proxy1, proxy2, productApi3ReaderProxyV1, productApi3ReaderProxyV1Compound } =
+              await helpers.loadFixture(deploy);
+            expect(await productApi3ReaderProxyV1.proxy1()).to.equal(await proxy1.getAddress());
+            expect(await productApi3ReaderProxyV1.proxy2()).to.equal(await proxy2.getAddress());
+            expect(await productApi3ReaderProxyV1.dappId()).to.equal(await proxy1.dappId());
+            expect(await productApi3ReaderProxyV1.dappId()).to.equal(await proxy2.dappId());
+            expect(await productApi3ReaderProxyV1Compound.proxy1()).to.equal(await proxy1.getAddress());
+            expect(await productApi3ReaderProxyV1Compound.proxy2()).to.equal(
+              await productApi3ReaderProxyV1.getAddress()
             );
+            expect(await productApi3ReaderProxyV1Compound.dappId()).to.equal(await proxy1.dappId());
+            expect(await productApi3ReaderProxyV1Compound.dappId()).to.equal(await productApi3ReaderProxyV1.dappId());
           });
         });
         context('proxy1 is the same as proxy2', function () {
           it('reverts', async function () {
-            const { api3ReaderProxyV1EthUsd, roles } = await helpers.loadFixture(deploy);
+            const { proxy1, roles } = await helpers.loadFixture(deploy);
             const productApi3ReaderProxyV1Factory = await ethers.getContractFactory(
               'ProductApi3ReaderProxyV1',
               roles.deployer
             );
-            await expect(
-              productApi3ReaderProxyV1Factory.deploy(
-                await api3ReaderProxyV1EthUsd.getAddress(),
-                await api3ReaderProxyV1EthUsd.getAddress()
-              )
-            )
+            await expect(productApi3ReaderProxyV1Factory.deploy(await proxy1.getAddress(), await proxy1.getAddress()))
               .to.be.revertedWithCustomError(productApi3ReaderProxyV1Factory, 'SameProxyAddress')
               .withArgs();
           });
@@ -163,14 +77,12 @@ describe('ProductApi3ReaderProxyV1', function () {
       });
       context('proxy2 is zero address', function () {
         it('reverts', async function () {
-          const { api3ReaderProxyV1EthUsd, roles } = await helpers.loadFixture(deploy);
+          const { proxy1, roles } = await helpers.loadFixture(deploy);
           const productApi3ReaderProxyV1Factory = await ethers.getContractFactory(
             'ProductApi3ReaderProxyV1',
             roles.deployer
           );
-          await expect(
-            productApi3ReaderProxyV1Factory.deploy(await api3ReaderProxyV1EthUsd.getAddress(), ethers.ZeroAddress)
-          )
+          await expect(productApi3ReaderProxyV1Factory.deploy(await proxy1.getAddress(), ethers.ZeroAddress))
             .to.be.revertedWithCustomError(productApi3ReaderProxyV1Factory, 'ZeroProxyAddress')
             .withArgs();
         });
@@ -178,14 +90,12 @@ describe('ProductApi3ReaderProxyV1', function () {
     });
     context('proxy1 is zero address', function () {
       it('reverts', async function () {
-        const { api3ReaderProxyV1SolEth, roles } = await helpers.loadFixture(deploy);
+        const { proxy1, roles } = await helpers.loadFixture(deploy);
         const productApi3ReaderProxyV1Factory = await ethers.getContractFactory(
           'ProductApi3ReaderProxyV1',
           roles.deployer
         );
-        await expect(
-          productApi3ReaderProxyV1Factory.deploy(ethers.ZeroAddress, await api3ReaderProxyV1SolEth.getAddress())
-        )
+        await expect(productApi3ReaderProxyV1Factory.deploy(ethers.ZeroAddress, await proxy1.getAddress()))
           .to.be.revertedWithCustomError(productApi3ReaderProxyV1Factory, 'ZeroProxyAddress')
           .withArgs();
       });
@@ -194,11 +104,10 @@ describe('ProductApi3ReaderProxyV1', function () {
 
   describe('read', function () {
     it('reads the product of the proxy rates', async function () {
-      const { productApi3ReaderProxyV1SolUsd, api3ReaderProxyV1EthUsd, api3ReaderProxyV1SolEth } =
-        await helpers.loadFixture(deploy);
-      const [baseBeaconValueEthUsd] = await api3ReaderProxyV1EthUsd.read();
-      const [baseBeaconValueSolEth] = await api3ReaderProxyV1SolEth.read();
-      const dataFeed = await productApi3ReaderProxyV1SolUsd.read();
+      const { proxy1, proxy2, productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      const [baseBeaconValueEthUsd] = await proxy1.read();
+      const [baseBeaconValueSolEth] = await proxy2.read();
+      const dataFeed = await productApi3ReaderProxyV1.read();
       expect(dataFeed.value).to.equal((baseBeaconValueEthUsd * baseBeaconValueSolEth) / 10n ** 18n);
       expect(dataFeed.timestamp).to.equal(await helpers.time.latest());
     });
@@ -206,86 +115,85 @@ describe('ProductApi3ReaderProxyV1', function () {
 
   describe('latestAnswer', function () {
     it('returns proxy value', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
-      const [value] = await productApi3ReaderProxyV1SolUsd.read();
-      expect(await productApi3ReaderProxyV1SolUsd.latestAnswer()).to.be.equal(value);
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      const [value] = await productApi3ReaderProxyV1.read();
+      expect(await productApi3ReaderProxyV1.latestAnswer()).to.be.equal(value);
     });
   });
 
   describe('latestTimestamp', function () {
     it('returns proxy value', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
-      const [, timestamp] = await productApi3ReaderProxyV1SolUsd.read();
-      expect(await productApi3ReaderProxyV1SolUsd.latestTimestamp()).to.be.equal(timestamp);
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      const [, timestamp] = await productApi3ReaderProxyV1.read();
+      expect(await productApi3ReaderProxyV1.latestTimestamp()).to.be.equal(timestamp);
     });
   });
 
   describe('latestRound', function () {
     it('reverts', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
-      await expect(productApi3ReaderProxyV1SolUsd.latestRound())
-        .to.be.revertedWithCustomError(productApi3ReaderProxyV1SolUsd, 'FunctionIsNotSupported')
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      await expect(productApi3ReaderProxyV1.latestRound())
+        .to.be.revertedWithCustomError(productApi3ReaderProxyV1, 'FunctionIsNotSupported')
         .withArgs();
     });
   });
 
   describe('getAnswer', function () {
     it('reverts', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
       const blockNumber = await ethers.provider.getBlockNumber();
-      await expect(productApi3ReaderProxyV1SolUsd.getAnswer(blockNumber))
-        .to.be.revertedWithCustomError(productApi3ReaderProxyV1SolUsd, 'FunctionIsNotSupported')
+      await expect(productApi3ReaderProxyV1.getAnswer(blockNumber))
+        .to.be.revertedWithCustomError(productApi3ReaderProxyV1, 'FunctionIsNotSupported')
         .withArgs();
     });
   });
 
   describe('getTimestamp', function () {
     it('reverts', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
       const blockNumber = await ethers.provider.getBlockNumber();
-      await expect(productApi3ReaderProxyV1SolUsd.getTimestamp(blockNumber))
-        .to.be.revertedWithCustomError(productApi3ReaderProxyV1SolUsd, 'FunctionIsNotSupported')
+      await expect(productApi3ReaderProxyV1.getTimestamp(blockNumber))
+        .to.be.revertedWithCustomError(productApi3ReaderProxyV1, 'FunctionIsNotSupported')
         .withArgs();
     });
   });
 
   describe('decimals', function () {
     it('returns 18', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
-      expect(await productApi3ReaderProxyV1SolUsd.decimals()).to.equal(18);
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      expect(await productApi3ReaderProxyV1.decimals()).to.equal(18);
     });
   });
 
   describe('description', function () {
     it('returns empty string', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
-      expect(await productApi3ReaderProxyV1SolUsd.description()).to.equal('');
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      expect(await productApi3ReaderProxyV1.description()).to.equal('');
     });
   });
 
   describe('version', function () {
     it('returns 4914', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
-      expect(await productApi3ReaderProxyV1SolUsd.version()).to.equal(4914);
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      expect(await productApi3ReaderProxyV1.version()).to.equal(4914);
     });
   });
 
   describe('getRoundData', function () {
     it('reverts', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
       const blockNumber = await ethers.provider.getBlockNumber();
-      await expect(productApi3ReaderProxyV1SolUsd.getRoundData(blockNumber))
-        .to.be.revertedWithCustomError(productApi3ReaderProxyV1SolUsd, 'FunctionIsNotSupported')
+      await expect(productApi3ReaderProxyV1.getRoundData(blockNumber))
+        .to.be.revertedWithCustomError(productApi3ReaderProxyV1, 'FunctionIsNotSupported')
         .withArgs();
     });
   });
 
   describe('latestRoundData', function () {
     it('returns approximated round data', async function () {
-      const { productApi3ReaderProxyV1SolUsd } = await helpers.loadFixture(deploy);
-      const [value, timestamp] = await productApi3ReaderProxyV1SolUsd.read();
-      const [roundId, answer, startedAt, updatedAt, answeredInRound] =
-        await productApi3ReaderProxyV1SolUsd.latestRoundData();
+      const { productApi3ReaderProxyV1 } = await helpers.loadFixture(deploy);
+      const [value, timestamp] = await productApi3ReaderProxyV1.read();
+      const [roundId, answer, startedAt, updatedAt, answeredInRound] = await productApi3ReaderProxyV1.latestRoundData();
       expect(roundId).to.equal(0);
       expect(answer).to.equal(value);
       expect(startedAt).to.equal(timestamp);


### PR DESCRIPTION
Closes #24 

## Changes
* Adds `dappId` immutable variable to all combinator contracts. These are set by reading the underlying proxy.dappId() (except for  NormalizedApi3ReaderProxyV1)
* Casts underlying proxies to `IApi3ReaderProxyV1`
* `NormalizedApi3ReaderProxyV1` now requires a `dappId` to be pass in the constructor
* Validates that proxies dappId are equal in `ProductApi3ReaderProxyV1`
* Replaces @api3/contracts imports with `MockApi3ReaderProxyV1` test contract to make testing simpler

### Notes
* The dappId immutable variable is needed because `dappId()` in `IApi3ReaderProxyV1` is not [marked](https://github.com/api3dao/contracts/blob/main/contracts/api3-server-v1/proxies/interfaces/IApi3ReaderProxyV1.sol#L21) as `view`
* The cast to `IApi3ReaderProxyV1` still feels kind of wrong to me since the underlying proxies might be another combinator proxy which might not even expose a `dapiName()` function for example. I think it might be more accurate to create a `IApi3ReaderProxyWithDappId` or similar that inherints from `IApi3ReaderProxy`and adds a function `dappId() external view returns (uint256);`