### PR TITLE
Implement wrapper for spSEI

### DIFF
--- a/contracts/SpSEIApi3ReaderProxyV1.sol
+++ b/contracts/SpSEIApi3ReaderProxyV1.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.27;
 import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
 import "./interfaces/ISpSEI.sol";
 
-/// @title An immutable proxy contract that reads the spSEI per SEI ratio
+/// @title An immutable proxy contract that reads the SEI per spSEI ratio
 /// directly from the spSEI contract on Sei network.
 /// @dev This contract implements only the IApi3ReaderProxy interface and not the
 /// AggregatorV2V3Interface which is usually implemented by Api3 proxies. The
@@ -23,9 +23,9 @@ contract SpSEIApi3ReaderProxyV1 is IApi3ReaderProxy {
         override
         returns (int224 value, uint32 timestamp)
     {
-        uint256 exchangeRatio = ISpSEI(SP_SEI).getExchangeRatio();
+        uint256 exchangeRatio = ISpSEI(SP_SEI).getExchangeRatio(); // Returns the spSEI amount worth of 1 SEI.
 
-        value = int224(int256(exchangeRatio)); // spSEI value already has 18 decimals.
+        value = int224(int256(1e36) / int256(exchangeRatio)); // spSEI amount uses 18 decimals.
         timestamp = uint32(block.timestamp);
     }
 }

--- a/contracts/SpSEIApi3ReaderProxyV1.sol
+++ b/contracts/SpSEIApi3ReaderProxyV1.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+import "@api3/contracts/interfaces/IApi3ReaderProxy.sol";
+import "./interfaces/ISpSEI.sol";
+
+/// @title An immutable proxy contract that reads the spSEI per SEI ratio
+/// directly from the spSEI contract on Sei network.
+/// @dev This contract implements only the IApi3ReaderProxy interface and not the
+/// AggregatorV2V3Interface which is usually implemented by Api3 proxies. The
+/// user of this contract needs to be aware of this limitation and only use this
+/// contract where the IApi3ReaderProxy interface is expected.
+contract SpSEIApi3ReaderProxyV1 is IApi3ReaderProxy {
+    /// @notice The address of the spSEI contract on Sei network.
+    address public constant SP_SEI = 0xa776cbdD531FB3b7BA6c8fF0fBdEb84138CAB78B;
+
+    /// @inheritdoc IApi3ReaderProxy
+    /// @dev Returns the spSEI/SEI exchange rate with 18 decimals precision.
+    /// The timestamp returned is the current block timestamp.
+    function read()
+        public
+        view
+        override
+        returns (int224 value, uint32 timestamp)
+    {
+        uint256 exchangeRatio = ISpSEI(SP_SEI).getExchangeRatio();
+
+        value = int224(int256(exchangeRatio)); // spSEI value already has 18 decimals.
+        timestamp = uint32(block.timestamp);
+    }
+}

--- a/contracts/interfaces/ISpSEI.sol
+++ b/contracts/interfaces/ISpSEI.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.27;
 
 /// @title A minimal interface for the spSEI contract on Sei network
 /// @dev This interface only includes the getExchangeRatio function needed to read
-/// the exchange rate between spSEI and SEI.
+/// the exchange rate between SEI and spSEI.
 interface ISpSEI {
     /// @notice Returns the amount of spSEI that corresponds to 1 SEI
-    /// @return The spSEI/SEI exchange rate with 18 decimals precision
+    /// @return The SEI/spSEI exchange rate with 18 decimals precision
     function getExchangeRatio() external view returns (uint256);
 }

--- a/contracts/interfaces/ISpSEI.sol
+++ b/contracts/interfaces/ISpSEI.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.27;
+
+/// @title A minimal interface for the spSEI contract on Sei network
+/// @dev This interface only includes the getExchangeRatio function needed to read
+/// the exchange rate between spSEI and SEI.
+interface ISpSEI {
+    /// @notice Returns the amount of spSEI that corresponds to 1 SEI
+    /// @return The spSEI/SEI exchange rate with 18 decimals precision
+    function getExchangeRatio() external view returns (uint256);
+}

--- a/deploy/006_deploy_takara_spsei_sei_adapter.ts
+++ b/deploy/006_deploy_takara_spsei_sei_adapter.ts
@@ -1,0 +1,45 @@
+import type { HardhatRuntimeEnvironment } from 'hardhat/types';
+
+import { getDeploymentName } from '../src';
+
+export const CONTRACT_NAME = 'SpSEIApi3ReaderProxyV1';
+
+module.exports = async (hre: HardhatRuntimeEnvironment) => {
+  const { deployments, getUnnamedAccounts, run } = hre;
+  const { deploy, log } = deployments;
+
+  const [deployerAddress] = await getUnnamedAccounts();
+  if (!deployerAddress) {
+    throw new Error('No deployer address found.');
+  }
+  log(`Deployer address: ${deployerAddress}`);
+
+  const constructorArgs = [] as any[];
+  const constructorArgTypes = [] as any[];
+
+  const deploymentName = getDeploymentName(CONTRACT_NAME, constructorArgTypes, constructorArgs);
+  log(`Generated deterministic deployment name for this instance: ${deploymentName}`);
+
+  const deployment = await deploy(deploymentName, {
+    contract: CONTRACT_NAME,
+    from: deployerAddress,
+    args: constructorArgs,
+    log: true,
+  });
+
+  log(`Deployed ${deploymentName} at address: ${deployment.address}`);
+
+  log(
+    `Attempting verification of ${deploymentName} (contract type ${CONTRACT_NAME}) at ${deployment.address} (already waited for confirmations)...`
+  );
+  await run('verify:verify', {
+    address: deployment.address,
+    constructorArguments: deployment.args,
+  });
+  // Successfully verified contract SpSEIApi3ReaderProxyV1 on the block explorer.
+  // https://seitrace.com/address/0x1a0F087e0A4084978BfCe0B882579fae52C7909C#code
+
+  // NETWORK=sei_pacific_1 PROXY1=0x1a0F087e0A4084978BfCe0B882579fae52C7909C PROXY2=0x0f6a4D320c29512476374EF142F1e70aBe6D88F3 pnpm deploy:ProductApi3ReaderProxyV1
+};
+
+module.exports.tags = [CONTRACT_NAME];

--- a/deploy/006_deploy_takara_spsei_sei_adapter.ts
+++ b/deploy/006_deploy_takara_spsei_sei_adapter.ts
@@ -36,10 +36,6 @@ module.exports = async (hre: HardhatRuntimeEnvironment) => {
     address: deployment.address,
     constructorArguments: deployment.args,
   });
-  // Successfully verified contract SpSEIApi3ReaderProxyV1 on the block explorer.
-  // https://seitrace.com/address/0x1a0F087e0A4084978BfCe0B882579fae52C7909C#code
-
-  // NETWORK=sei_pacific_1 PROXY1=0x1a0F087e0A4084978BfCe0B882579fae52C7909C PROXY2=0x0f6a4D320c29512476374EF142F1e70aBe6D88F3 pnpm deploy:ProductApi3ReaderProxyV1
 };
 
 module.exports.tags = [CONTRACT_NAME];

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -6,8 +6,33 @@ import 'dotenv/config';
 import type { HardhatUserConfig } from 'hardhat/config';
 
 const config: HardhatUserConfig = {
-  etherscan: hardhatConfig.etherscan(),
-  networks: hardhatConfig.networks(),
+  // NOTE: According to https://docs.sei.io/evm/evm-verify-contracts#config-file
+  etherscan: {
+    ...hardhatConfig.etherscan(),
+    apiKey: {
+      sei_pacific_1: 'dummy',
+    },
+    customChains: [
+      {
+        network: 'sei_pacific_1',
+        chainId: 1329,
+        urls: {
+          apiURL: 'https://seitrace.com/pacific-1/api',
+          browserURL: 'https://seitrace.com',
+        },
+      },
+    ],
+  },
+  networks: {
+    ...hardhatConfig.networks(),
+    sei_pacific_1: {
+      url: 'https://evm-rpc.sei-apis.com',
+      chainId: 1329,
+      accounts: { mnemonic: process.env.MNEMONIC ?? '' },
+      gas: 'auto',
+      gasPrice: 'auto',
+    },
+  },
   solidity: {
     compilers: [
       {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "deploy:ProductApi3ReaderProxyV1": "hardhat deploy --network $NETWORK --tags ProductApi3ReaderProxyV1",
     "deploy:PriceCappedApi3ReaderProxyV1": "hardhat deploy --network $NETWORK --tags PriceCappedApi3ReaderProxyV1",
     "deploy:ScaledApi3FeedProxyV1": "hardhat deploy --network $NETWORK --tags ScaledApi3FeedProxyV1",
+    "deploy:SpSEIApi3ReaderProxyV1": "hardhat deploy --network $NETWORK --tags SpSEIApi3ReaderProxyV1",
     "lint": "pnpm run prettier:check && pnpm run lint:eslint && pnpm run lint:solhint",
     "lint:solhint": "solhint ./contracts/**/*.sol",
     "lint:eslint": "eslint . --ext .js,.ts",


### PR DESCRIPTION
An adapter contract similar to https://etherscan.io/address/0xeC4031539b851eEc918b41FE3e03d7236fEc7be8#readContract and https://etherscan.io/address/0x3EA363B8CE16A26BFF70484883587DcF7E53C27d (proxy number 1 in the product reader contract).

The idea is to take a spSEI contract and compose its exchange rate with SEI price natively on SEI network. 