### PR TITLE
Configure package.json for npm package publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,16 @@
     "url": "https://github.com/api3dao/data-feed-proxy-combinators.git"
   },
   "private": false,
-  "main": "dist/src/index",
-  "types": "dist/src/index",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "files": [
-    "vendor",
+    "contracts",
+    "typechain-types",
     "dist"
   ],
+  "exports": {
+    ".": "./dist/src/index.js"
+  },
   "scripts": {
     "build": "pnpm build:hardhat && tsc -p tsconfig.build.json",
     "build:hardhat": "hardhat --config hardhat.build.config.ts compile",


### PR DESCRIPTION
Related to #38 

Tested locally by running `pnpm pack` to create a TAR compressed file and importing it in another repo.