### PR TITLE
Makes sure to clone the repo with all associated tags

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -66,7 +66,6 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v3


### PR DESCRIPTION
Should fix CI [error](https://github.com/api3dao/data-feed-proxy-combinators/actions/runs/18228269982/job/51905278213) on tag-and-release job 